### PR TITLE
Enable cross build down to sbt 0.13.x; add snykProject and snykBinary settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.class
 *.log
+**/target
+.idea

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "sbt-snyk"
 organization := "com.github.tom-walford"
-version := "0.2.0"
+version := "0.2.1-PR-SNAPSHOT"
 
 scalaVersion := "2.12.8"
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,8 @@ version := "0.2.0"
 
 scalaVersion := "2.12.8"
 
+crossSbtVersions := Seq("1.2.8", "0.13.17")
+
 enablePlugins(SbtPlugin)
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.2.7
+sbt.version = 1.2.8

--- a/src/main/scala-sbt-0.13/com/twalford/SbtCompat.scala
+++ b/src/main/scala-sbt-0.13/com/twalford/SbtCompat.scala
@@ -3,7 +3,10 @@ package com.twalford
 import sbt.Logger
 
 object SbtCompat {
-  private def sbtProcessLoggerLtoSSPProcessLogger(l: sbt.ProcessLogger): scala.sys.process.ProcessLogger = {
+
+  def convert(log: Logger): scala.sys.process.ProcessLogger = {
+    val l: sbt.ProcessLogger = Logger.log2PLog(log)
+
     new scala.sys.process.ProcessLogger {
       def out(s: => String): Unit = l.info(s)
       def err(s: => String): Unit = l.error(s)
@@ -11,6 +14,4 @@ object SbtCompat {
     }
   }
 
-  def convert(log: Logger): scala.sys.process.ProcessLogger =
-    sbtProcessLoggerLtoSSPProcessLogger(Logger.log2PLog(log))
 }

--- a/src/main/scala-sbt-0.13/com/twalford/SbtCompat.scala
+++ b/src/main/scala-sbt-0.13/com/twalford/SbtCompat.scala
@@ -5,7 +5,8 @@ import sbt.Logger
 object SbtCompat {
 
   def convert(log: Logger): scala.sys.process.ProcessLogger = {
-    val l: sbt.ProcessLogger = Logger.log2PLog(log)
+    // even in sbt 0.13 there is a built in implicit conversion for this part, but then a further conversion is necessary
+    val l: sbt.ProcessLogger = log
 
     new scala.sys.process.ProcessLogger {
       def out(s: => String): Unit = l.info(s)

--- a/src/main/scala-sbt-0.13/com/twalford/SbtCompat.scala
+++ b/src/main/scala-sbt-0.13/com/twalford/SbtCompat.scala
@@ -1,5 +1,7 @@
 package com.twalford
 
+import sbt.Logger
+
 object SbtCompat {
   private def sbtProcessLoggerLtoSSPProcessLogger(l: sbt.ProcessLogger): scala.sys.process.ProcessLogger = {
     new scala.sys.process.ProcessLogger {
@@ -9,6 +11,6 @@ object SbtCompat {
     }
   }
 
-  def convert(log: sbt.Logger): scala.sys.process.ProcessLogger =
-    sbtProcessLoggerLtoSSPProcessLogger(sbt.Logger.log2PLog(log))
+  def convert(log: Logger): scala.sys.process.ProcessLogger =
+    sbtProcessLoggerLtoSSPProcessLogger(Logger.log2PLog(log))
 }

--- a/src/main/scala-sbt-0.13/com/twalford/SbtCompat.scala
+++ b/src/main/scala-sbt-0.13/com/twalford/SbtCompat.scala
@@ -1,0 +1,14 @@
+package com.twalford
+
+object SbtCompat {
+  private def sbtProcessLoggerLtoSSPProcessLogger(l: sbt.ProcessLogger): scala.sys.process.ProcessLogger = {
+    new scala.sys.process.ProcessLogger {
+      def out(s: => String): Unit = l.info(s)
+      def err(s: => String): Unit = l.error(s)
+      def buffer[T](f: => T): T = l.buffer(f)
+    }
+  }
+
+  def convert(log: sbt.Logger): scala.sys.process.ProcessLogger =
+    sbtProcessLoggerLtoSSPProcessLogger(sbt.Logger.log2PLog(log))
+}

--- a/src/main/scala-sbt-1.0/com/twalford/SbtCompat.scala
+++ b/src/main/scala-sbt-1.0/com/twalford/SbtCompat.scala
@@ -3,6 +3,6 @@ package com.twalford
 import sbt.Logger
 
 private object SbtCompat {
-  def convert(log: Logger): scala.sys.process.ProcessLogger =
-    Logger.log2PLog(log)
+  // in sbt 1.x there is a built in implicit conversion all the way
+  def convert(log: Logger): scala.sys.process.ProcessLogger = log
 }

--- a/src/main/scala-sbt-1.0/com/twalford/SbtCompat.scala
+++ b/src/main/scala-sbt-1.0/com/twalford/SbtCompat.scala
@@ -1,0 +1,6 @@
+package com.twalford
+
+private object SbtCompat {
+  def convert(log: sbt.Logger): scala.sys.process.ProcessLogger =
+    sbt.Logger.log2PLog(log)
+}

--- a/src/main/scala-sbt-1.0/com/twalford/SbtCompat.scala
+++ b/src/main/scala-sbt-1.0/com/twalford/SbtCompat.scala
@@ -1,6 +1,8 @@
 package com.twalford
 
+import sbt.Logger
+
 private object SbtCompat {
-  def convert(log: sbt.Logger): scala.sys.process.ProcessLogger =
-    sbt.Logger.log2PLog(log)
+  def convert(log: Logger): scala.sys.process.ProcessLogger =
+    Logger.log2PLog(log)
 }

--- a/src/main/scala/com/twalford/SnykPlugin.scala
+++ b/src/main/scala/com/twalford/SnykPlugin.scala
@@ -14,7 +14,7 @@ object SnykPlugin extends AutoPlugin {
   }
 
   override def globalSettings: Seq[Def.Setting[_]] = Seq(
-    Global / concurrentRestrictions += Tags.exclusive(snykTag),
+    (concurrentRestrictions in Global) += Tags.exclusive(snykTag),
     aggregate in snykAuth := false,
     snykAuth := snykAuthTask.value
   )

--- a/src/main/scala/com/twalford/SnykPlugin.scala
+++ b/src/main/scala/com/twalford/SnykPlugin.scala
@@ -10,7 +10,9 @@ object SnykPlugin extends AutoPlugin {
   override def requires = DependencyGraphPlugin
   object autoImport {
     val SnykPlugin: AutoPlugin = self
+    val snykBinary = SnykTasks.snykBinary
     val snykOrganization = SnykTasks.snykOrganization
+    val snykProject = SnykTasks.snykProject
   }
 
   override def globalSettings: Seq[Def.Setting[_]] = Seq(
@@ -22,6 +24,9 @@ object SnykPlugin extends AutoPlugin {
   override lazy val projectSettings: Seq[Setting[_]] = Seq(
     snykTest := snykTestTask.value,
     snykMonitor := snykMonitorTask.value,
-    snykAuth := snykAuthTask.value
+    snykAuth := snykAuthTask.value,
+
+    snykBinary := "snyk",
+    snykProject := name.value
   )
 }

--- a/src/main/scala/com/twalford/SnykPlugin.scala
+++ b/src/main/scala/com/twalford/SnykPlugin.scala
@@ -18,7 +18,9 @@ object SnykPlugin extends AutoPlugin {
   override def globalSettings: Seq[Def.Setting[_]] = Seq(
     (concurrentRestrictions in Global) += Tags.exclusive(snykTag),
     aggregate in snykAuth := false,
-    snykAuth := snykAuthTask.value
+    snykAuth := snykAuthTask.value,
+
+    snykBinary := "snyk"
   )
 
   override lazy val projectSettings: Seq[Setting[_]] = Seq(
@@ -26,7 +28,6 @@ object SnykPlugin extends AutoPlugin {
     snykMonitor := snykMonitorTask.value,
     snykAuth := snykAuthTask.value,
 
-    snykBinary := "snyk",
     snykProject := name.value
   )
 }

--- a/src/main/scala/com/twalford/SnykTasks.scala
+++ b/src/main/scala/com/twalford/SnykTasks.scala
@@ -4,7 +4,7 @@ import com.twalford.SbtCompat._
 import sbt.ConcurrentRestrictions.Tag
 import sbt.{Def, settingKey, taskKey, UnprintableException}
 import sbt.Keys.{name, streams, thisProject}
-import sbt.util.Logger
+import sbt.Logger
 
 import scala.sys.process.Process
 

--- a/src/main/scala/com/twalford/SnykTasks.scala
+++ b/src/main/scala/com/twalford/SnykTasks.scala
@@ -1,9 +1,10 @@
 package com.twalford
 
+import com.twalford.SbtCompat._
 import sbt.ConcurrentRestrictions.Tag
 import sbt.{Def, settingKey, taskKey, UnprintableException}
 import sbt.Keys.{name, streams, thisProject}
-import sbt.internal.util.ManagedLogger
+import sbt.util.Logger
 
 import scala.sys.process.Process
 
@@ -42,7 +43,7 @@ object SnykTasks {
     checkForAuth(log)
   }.tag(snykTag)
 
-  private def checkForAuth(log: ManagedLogger): Unit = {
+  private def checkForAuth(log: Logger): Unit = {
     Option(System.getenv(authEnvVar)) match {
       case None =>
         log.info("No auth set up, but presumed we're running locally. Requesting auth via `snyk auth`")
@@ -53,13 +54,13 @@ object SnykTasks {
     }
   }
 
-  private def run(cmds: List[String], log: ManagedLogger): Unit = {
+  private def run(cmds: List[String], log: Logger): Unit = {
     val shell = if (sys.props("os.name").contains("Windows")) {
       List("cmd", "/c")
     } else {
       Nil
     }
-    val responseCode = Process(shell ::: cmds) ! log
+    val responseCode = Process(shell ::: cmds) ! convert(log)
     if (responseCode != 0) {
       throw SnykError
     }

--- a/src/main/scala/com/twalford/SnykTasks.scala
+++ b/src/main/scala/com/twalford/SnykTasks.scala
@@ -30,7 +30,7 @@ object SnykTasks {
   lazy val snykTestTask = Def.task {
     val log = streams.value.log
     val id = thisProject.value.id
-    run(List(snykBinary.value, "test", "--", escape(s"project $id")), log)
+    run(List(snykBinary.value, "test", s"--org=${snykOrganization.value}", s"--project-name=${snykProject.value}", "--", escape(s"project $id")), log)
   }.tag(snykTag)
 
   lazy val snykMonitorTask = Def.task {
@@ -42,7 +42,7 @@ object SnykTasks {
 
   lazy val snykAuthTask = Def.task {
     val log = streams.value.log
-    val cmd = List(snykBinary.value, "auth")
+    val cmd = List(snykBinary.value, "auth", s"--org=${snykOrganization.value}")
     sys.env.get(authEnvVar) match {
       case None =>
         log.info(s"No auth set up, but presumed we're running locally. Requesting auth via `${cmd.mkString(" ")}`")
@@ -59,6 +59,7 @@ object SnykTasks {
     } else {
       Nil
     }
+    log.info(s"Running `${(shell ::: cmds).mkString(" ")}`")
     val responseCode = Process(shell ::: cmds) ! convert(log)
     if (responseCode != 0) {
       throw SnykError

--- a/src/main/scala/com/twalford/SnykTasks.scala
+++ b/src/main/scala/com/twalford/SnykTasks.scala
@@ -12,8 +12,8 @@ object SnykTasks {
   private lazy val authEnvVar = "SNYK_TOKEN"
 
   val snykBinary = settingKey[String]("The snyk command to run. Defaults to 'snyk' for the case when snyk is on the $PATH; alternatively e.g. './node_modules/.bin/snyk'")
-  val snykOrganization = settingKey[String]("The snyk organization to report against (i.e. synk --org)")
-  val snykProject = settingKey[String]("The snyk project to report against (i.e. snyk --project).  Ideally the appId, but it must be unique.  Defaults to sbt project name.")
+  val snykOrganization = settingKey[String]("The snyk organization to report against (i.e. `synk --org`)")
+  val snykProject = settingKey[String]("The snyk project to report against (i.e. `snyk --project-name`).  Ideally the appId, but it must be unique.  Defaults to sbt project name.")
 
   val snykAuth = taskKey[Unit]("Authorizes a local snyk instance")
   val snykTest = taskKey[Unit]("Runs snyk test on the local project")
@@ -42,13 +42,14 @@ object SnykTasks {
 
   lazy val snykAuthTask = Def.task {
     val log = streams.value.log
+    val cmd = List(snykBinary.value, "auth")
     sys.env.get(authEnvVar) match {
       case None =>
-        log.info("No auth set up, but presumed we're running locally. Requesting auth via `snyk auth`")
-        run(List(snykBinary.value, "auth"), log)
+        log.info(s"No auth set up, but presumed we're running locally. Requesting auth via `${cmd.mkString(" ")}`")
+        run(cmd, log)
       case Some(auth) =>
         log.debug("Snyk using environment variable authorization, continuing")
-        run(List(snykBinary.value, "auth", auth), log)
+        run(cmd :+ auth, log)
     }
   }.tag(snykTag)
 


### PR DESCRIPTION
 - Uses the standard plugin cross compilation mechanism with a small shim to deal with logger differences
- enables `snykBinary in Global := "./path/to/snyk"`
- enables `snykProject := "my-project-name"`
- consistently sets `--org` and `--project-name` as appropriate
- small logging/help improvements

Backwards incompatibility:
- you now have to set `snykOrganization in Global :=` not merely `snykOrganization :=`.  I didn't want this, but I don't know enough about idiomatic use of sbt configuration axes to fix it.  Similarly I would prefer users not to have to set `snykBinary in Global`.